### PR TITLE
fix: allow authenticated users to access /users/status route

### DIFF
--- a/routes/userStatus.js
+++ b/routes/userStatus.js
@@ -21,9 +21,7 @@ const { authorizeAndAuthenticate } = require("../middlewares/authorizeUsersAndSe
 const ROLES = require("../constants/roles");
 const { Services } = require("../constants/bot");
 
-// TODO: Have a discussion, if this 'users/status' needs to be open or protected.
-// For now making it protected and super_user only to sort the high firestore read issues, for usersStatus collection
-router.get("/", authenticate, authorizeRoles([SUPERUSER]), validateGetQueryParams, getUserStatusControllers);
+router.get("/", authenticate, validateGetQueryParams, getUserStatusControllers);
 router.get("/self", authenticate, getUserStatus);
 router.get("/:userId", getUserStatus);
 router.patch("/self", authenticate, validateUserStatus, updateUserStatusController); // this route is being deprecated, please use /users/status/:userId PATCH endpoint instead.

--- a/test/integration/userStatus.test.js
+++ b/test/integration/userStatus.test.js
@@ -61,7 +61,7 @@ describe("UserStatus", function () {
       chai
         .request(app)
         .get("/users/status")
-        .set("cookie", `${cookieName}=${superUserAuthToken}`)
+        .set("cookie", `${cookieName}=${jwt}`)
         .end((err, res) => {
           if (err) {
             return done(err);
@@ -86,10 +86,7 @@ describe("UserStatus", function () {
       await updateUserStatus(nonArchivedIdleUserId, generateUserStatusData("IDLE", new Date(), new Date()));
       const nonArchivedActiveUserId = await addUser(userData[8]);
       await updateUserStatus(nonArchivedActiveUserId, generateUserStatusData("ACTIVE", new Date(), new Date()));
-      const response = await chai
-        .request(app)
-        .get("/users/status?state=IDLE")
-        .set("cookie", `${cookieName}=${superUserAuthToken}`);
+      const response = await chai.request(app).get("/users/status?state=IDLE").set("cookie", `${cookieName}=${jwt}`);
       expect(response).to.have.status(200);
       expect(response.body.message).to.equal("All User Status found successfully.");
       expect(response.body.totalUserStatus).to.be.a("number");
@@ -99,10 +96,7 @@ describe("UserStatus", function () {
     });
 
     it("Should return pagination links with empty next/prev on a single page", async function () {
-      const response = await chai
-        .request(app)
-        .get("/users/status")
-        .set("cookie", `${cookieName}=${superUserAuthToken}`);
+      const response = await chai.request(app).get("/users/status").set("cookie", `${cookieName}=${jwt}`);
       expect(response).to.have.status(200);
       expect(response.body.links).to.be.a("object");
       expect(response.body.links.next).to.equal("");
@@ -116,19 +110,13 @@ describe("UserStatus", function () {
 
       const userIdsFromResponse = (response) => response.body.allUserStatus.map((status) => status.userId);
 
-      const firstPage = await chai
-        .request(app)
-        .get("/users/status?size=2")
-        .set("cookie", `${cookieName}=${superUserAuthToken}`);
+      const firstPage = await chai.request(app).get("/users/status?size=2").set("cookie", `${cookieName}=${jwt}`);
       expect(firstPage).to.have.status(200);
       expect(firstPage.body.allUserStatus.length).to.equal(2);
       expect(firstPage.body.links.next).to.not.equal("");
       expect(firstPage.body.links.prev).to.equal("");
 
-      const secondPage = await chai
-        .request(app)
-        .get(firstPage.body.links.next)
-        .set("cookie", `${cookieName}=${superUserAuthToken}`);
+      const secondPage = await chai.request(app).get(firstPage.body.links.next).set("cookie", `${cookieName}=${jwt}`);
       expect(secondPage).to.have.status(200);
       expect(secondPage.body.allUserStatus.length).to.equal(2);
       expect(secondPage.body.links.prev).to.not.equal("");
@@ -137,7 +125,7 @@ describe("UserStatus", function () {
       const firstPageAgain = await chai
         .request(app)
         .get(secondPage.body.links.prev)
-        .set("cookie", `${cookieName}=${superUserAuthToken}`);
+        .set("cookie", `${cookieName}=${jwt}`);
       expect(firstPageAgain).to.have.status(200);
       expect(userIdsFromResponse(firstPageAgain)).to.have.members(userIdsFromResponse(firstPage));
     });


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 22 Jul , 2026
<!--Developer Name Here-->
Developer Name: @AnujChhikara

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- NA
## Tech Doc Link
<!--Issue ticket this PR closes-->
- NA
## Business Doc Link
<!--Issue ticket this PR closes-->
- NA
## Description
PR #2599 temporarily restricted `GET /users/status` to super users (`authorizeRoles([SUPERUSER])`) to mitigate high Firestore reads on the `usersStatus` collection, leaving a TODO to revisit whether the route should stay protected.

Since then, we have added pagination to this route and done the query optimization for it (active-users-first, paginated, batched reads), which addressed the high Firestore read concern that motivated the restriction. Because that optimization is now in place, the super_user restriction is no longer needed, so this PR reverts `GET /users/status` to a normally authenticated route.

- `routes/userStatus.js`: `GET /` now runs `authenticate` -> `validateGetQueryParams` -> `getUserStatusControllers` (dropped `authorizeRoles([SUPERUSER])`), and removed the obsolete super_user TODO comment.
- `test/integration/userStatus.test.js`: switched the `GET /users/status` tests from the super_user token back to a normal user token so they assert a regular authenticated user can access the route. The unauthorized (401) test is retained.

Note: the super_user restriction on `/users/search` (also added in #2599) is intentionally left unchanged; this PR scopes only to `/users/status`.

<!--Description of the changes made in this PR-->

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [x] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [x] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
<img width="1511" height="606" alt="image" src="https://github.com/user-attachments/assets/afad062e-8d40-477b-ba92-73125bce0278" />
<img width="942" height="837" alt="image" src="https://github.com/user-attachments/assets/a3ffb678-d4d0-4bd4-9263-1278028157a7" />


</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->
<img width="863" height="415" alt="image" src="https://github.com/user-attachments/assets/e4529ce3-41df-46dd-9ace-ddc72e6d12ea" />

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes

<!--Any additional notes, considerations or explanations for reviewers-->